### PR TITLE
Issue #SB-26626 fix: Status color is wrong when Question Set is replayed

### DIFF
--- a/projects/quml-library/package-lock.json
+++ b/projects/quml-library/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-v9",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/projects/quml-library/package.json
+++ b/projects/quml-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-v9",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "peerDependencies": {
     "@angular/common": "^8.0.0",
     "@angular/core": "^8.0.0",

--- a/projects/quml-library/src/lib/player/player.component.ts
+++ b/projects/quml-library/src/lib/player/player.component.ts
@@ -651,6 +651,7 @@ export class PlayerComponent implements OnInit, AfterViewInit {
     this.disableNext = false;
     this.currentSlideIndex = 1;
     this.car.selectSlide(1);
+    this.setSkippedClass(this.currentSlideIndex - 1);
     this.currentQuestionsMedia = _.get(this.questions[0], 'media');
     this.setImageZoom();
     setTimeout(() => {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-26626" title="SB-26626" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/secure/viewavatar?size=medium&avatarId=10304&avatarType=issuetype" />SB-26626</a>  Summary screen show different status for Q1 and for the rest of the questions 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules