### PR TITLE
Issue #SB-29062 fix: Stopped showing root instructions in the section startpage

### DIFF
--- a/projects/quml-library/package.json
+++ b/projects/quml-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-v9",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "peerDependencies": {
     "@angular/common": ">=9.0.0",
     "@angular/core": ">=9.0.0",

--- a/projects/quml-library/src/lib/section-player/section-player.component.html
+++ b/projects/quml-library/src/lib/section-player/section-player.component.html
@@ -25,7 +25,7 @@
       <div class="landscape-content">
         <carousel class="landscape-center" [interval]="0" [showIndicators]="false" [noWrap]="true" #myCarousel (activeSlideChange)="activeSlideChange($event)">
           <slide>
-            <quml-startpage [instructions]="showRootInstruction ? parentConfig?.instructions : sectionConfig.metadata?.instructions?.default || parentConfig?.instructions"  [points]="points"
+            <quml-startpage [instructions]="showRootInstruction ? parentConfig?.instructions : sectionConfig.metadata?.instructions?.default"  [points]="points"
               [time]="showRootInstruction ? timeLimit : null" [showTimer]="showTimer" [totalNoOfQuestions]="showRootInstruction ? parentConfig?.questionCount : noOfQuestions"
               [contentName]="showRootInstruction ? parentConfig?.contentName : parentConfig?.isSectionsAvailable ? sectionConfig?.metadata?.name : parentConfig?.contentName">
             </quml-startpage>


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-29062" title="SB-29062" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />SB-29062</a>   If the User is not given any  instructions in sections, Root node Instructions are visible in section Instructions while Previewing
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules