### PR TITLE
Issue #SB-30690 fix: Setting 1 mark for the question when there is only one question in the section

### DIFF
--- a/projects/quml-library/package.json
+++ b/projects/quml-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-quml-player-v9",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "peerDependencies": {
     "@angular/common": ">=9.0.0",
     "@angular/core": ">=9.0.0",

--- a/projects/quml-library/src/lib/section-player/section-player.component.ts
+++ b/projects/quml-library/src/lib/section-player/section-player.component.ts
@@ -90,7 +90,6 @@ export class SectionPlayerComponent implements OnChanges, AfterViewInit {
   disabledHandle: any;
   isAssessEventRaised = false;
   isShuffleQuestions = false;
-  isSingleQuestion = false;
   shuffleOptions: boolean;
 
   constructor(
@@ -179,7 +178,6 @@ export class SectionPlayerComponent implements OnChanges, AfterViewInit {
     }
     this.threshold = this.sectionConfig.context?.threshold || 3;
     this.questionIds = _.cloneDeep(this.sectionConfig.metadata.childNodes);
-    this.isSingleQuestion = this.questionIds.length === 1;
 
     /* istanbul ignore else */
     if (this.parentConfig.isReplayed) {
@@ -432,7 +430,7 @@ export class SectionPlayerComponent implements OnChanges, AfterViewInit {
   updateScoreForShuffledQuestion() {
     const currentIndex = this.myCarousel.getCurrentSlideIndex() - 1;
 
-    if (this.isShuffleQuestions && !this.isSingleQuestion) {
+    if (this.isShuffleQuestions) {
       this.updateScoreBoard(currentIndex, 'correct', undefined, DEFAULT_SCORE);
     }
   }
@@ -899,7 +897,7 @@ export class SectionPlayerComponent implements OnChanges, AfterViewInit {
   getScore(currentIndex, key, isCorrectAnswer, selectedOption?) {
     /* istanbul ignore else */
     if (isCorrectAnswer) {
-      if (this.isShuffleQuestions && !this.isSingleQuestion) {
+      if (this.isShuffleQuestions) {
         return DEFAULT_SCORE;
       }
       return this.questions[currentIndex].responseDeclaration[key].correctResponse.outcomes.SCORE ?


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/SB-30690" title="SB-30690" target="_blank"><img alt="Defect" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10304?size=medium" />SB-30690</a>  Question marks are not getting to be 1 when shuffle is enable and Max question is selected 
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules