### PR TITLE
Issue #IQ-139 fix: Fixed showing show solution button for incorrect response

### DIFF
--- a/projects/quml-library/package.json
+++ b/projects/quml-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@project-sunbird/sunbird-quml-player",
-  "version": "5.2.0-beta.3",
+  "version": "5.2.0-beta.4",
   "peerDependencies": {
     "@angular/common": ">=12.2.16",
     "@angular/core": ">=12.2.16",

--- a/projects/quml-library/src/lib/alert/alert.component.html
+++ b/projects/quml-library/src/lib/alert/alert.component.html
@@ -21,9 +21,12 @@
       
 
       <div class="quml-alert__solution-container">
-        <div class="quml-alert__try-again" *ngIf="alertType === 'wrong' || (alertType === 'correct' && showSolutionButton)">
+        <div class="quml-alert__try-again" *ngIf="alertType === 'wrong'">
           <span tabindex="0" id="wrongButton" *ngIf="alertType === 'wrong'" (click)="close('tryAgain')" (keyup.enter)="close('tryAgain')"  aria-label="Try again">Try again</span>
-          <span tabindex="0" id="correctButton" *ngIf="alertType === 'correct' && showSolutionButton" (click)="viewSolution()" (keyup.enter)="viewSolution()"  aria-label="View Solution">View Solution</span>
+          <!-- TODO: should add some label for correct response when solution is off <span *ngIf="alertType === 'correct' && !showSolutionButton">Correct</span> --> 
+        </div>
+        <div class="quml-alert__view-solution" *ngIf="showSolutionButton">
+          <span tabindex="0" id="correctButton" (click)="viewSolution()" (keyup.enter)="viewSolution()"  aria-label="View Solution">View Solution</span>
         </div>
       </div>
 

--- a/projects/quml-library/src/lib/alert/alert.component.ts
+++ b/projects/quml-library/src/lib/alert/alert.component.ts
@@ -4,15 +4,18 @@ import {
 } from '@angular/core';
 import { fromEvent, Subscription } from 'rxjs';
 
+type AlertType = "correct" | "wrong";
+
 @Component({
   selector: 'quml-alert',
   templateUrl: './alert.component.html',
   styleUrls: ['./alert.component.scss']
 })
 export class AlertComponent implements OnInit, AfterViewInit, OnDestroy {
-  @Input() alertType: any;
+  @Input() alertType: AlertType;
   @Input() isHintAvailable: boolean;
   @Input() showSolutionButton: boolean;
+
   @Output() closeAlert = new EventEmitter();
   @Output() showSolution = new EventEmitter();
   @Output() showHint = new EventEmitter();

--- a/projects/quml-library/src/lib/section-player/section-player.component.html
+++ b/projects/quml-library/src/lib/section-player/section-player.component.html
@@ -120,7 +120,7 @@
   </div>
 
   <quml-alert *ngIf="showAlert && showFeedBack" [alertType]="alertType" [isHintAvailable]="showHints"
-    [showSolutionButton]="showUserSolution" (showSolution)="viewSolution()" (showHint)="viewHint()"
+    [showSolutionButton]="showUserSolution && currentSolutions" (showSolution)="viewSolution()" (showHint)="viewHint()"
     (closeAlert)="closeAlertBox($event)"></quml-alert>
 
   <quml-mcq-solutions *ngIf="showSolution" [question]="currentQuestion" [options]="currentOptions"


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://project-sunbird.atlassian.net/browse/IQ-139" title="IQ-139" target="_blank"><img alt="Bug" src="https://project-sunbird.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />IQ-139</a>  Try Again and View solution is not getting displayed on the question set preview while the user selects the incorrect answer in MCQ Question.
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

### Type of change

Please choose appropriate options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes in the below checkboxes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Ran Test A
- [ ] Ran Test B

**Test Configuration**:
* Software versions:
* Hardware versions:

### Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules